### PR TITLE
Update Spigot API version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19.3-R0.1-SNAPSHOT</version>
+            <version>1.20.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The Spigot API has been updated in the project's dependencies. The version has been changed from 1.19.3-R0.1-SNAPSHOT to 1.20.5-R0.1-SNAPSHOT.